### PR TITLE
fix plugin name issue #2 

### DIFF
--- a/C7CustomIcon/index.js
+++ b/C7CustomIcon/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = {
-  name: 'bpmn-js Plugin Example',
+  name: 'C7CustomIcons',
   script: './client/client.bundle.js'
 };


### PR DESCRIPTION
This fixes #2  by setting the name to an accurate name.

![image](https://github.com/user-attachments/assets/33da060f-66c2-468c-acea-f32f8e85c02c)
